### PR TITLE
Move parameters to input and clean the project

### DIFF
--- a/lurte.sh
+++ b/lurte.sh
@@ -15,7 +15,7 @@ function openAemet() {
     # Los años que queremos descargar
     i=$from
     while [ $i -le $to ]
-        do
+    do
         # Le pasamos un nombre al archivo que generaremos con todo el año
         entero="${i}-entero"
 
@@ -33,21 +33,22 @@ function openAemet() {
               --url 'https://opendata.aemet.es/opendata/api/valores/climatologicos/diarios/datos/fechaini/'${i}'-10-01T00:00:00UTC/fechafin/'${i}'-10-31T23:59:59UTC/estacion/'${station}'/?api_key='${apikey}''  >> $i.json && curl --silent --request GET --insecure \
               --url 'https://opendata.aemet.es/opendata/api/valores/climatologicos/diarios/datos/fechaini/'${i}'-11-01T00:00:00UTC/fechafin/'${i}'-11-30T23:59:59UTC/estacion/'${station}'/?api_key='${apikey}''  >> $i.json && curl --silent --request GET --insecure \
               --url 'https://opendata.aemet.es/opendata/api/valores/climatologicos/diarios/datos/fechaini/'${i}'-12-01T00:00:00UTC/fechafin/'${i}'-12-31T23:59:59UTC/estacion/'${station}'/?api_key='${apikey}'' >> $i.json &&
-             # El archivo que descargamos contiene demasiadas cosas que no sirven
-             # Vamos a quedarnos solo con la url de datos
-             sed -i '/descripcion/d;/estado/d;/metadatos/d' $i.json &&
-             sed -i 's/{//;s/}//;s/"//;s/ : //;s/datos//;s/",//;s/""//;s/  //' $i.json &&
-             # Ahora ejecutamos todas las url de datos de todo el año y descargamos su contenido en el mismo archivo
-             while read line; do
-                 # Eliminamos los archivos de los años ya que no nos sirven para nada
-                 rm -rf $i.json
-                 curl --silent --request GET --insecure "$line" >> $entero.json &&
-                 # Añadimos una coma al final de todos los archivos anuales para luego concatenar todos en el mismo archivo
-                 echo "," >> $entero.json
-             done < $i.json &&
-             # Le damos un respiro a la API, ya que nos baneara si hacemos demasiadas peticiones en poco tiempo
-             sleep 30
-        i=$((i+1))
+            # El archivo que descargamos contiene demasiadas cosas que no sirven
+            # Vamos a quedarnos solo con la url de datos
+            sed -i '/descripcion/d;/estado/d;/metadatos/d' $i.json &&
+            sed -i 's/{//;s/}//;s/"//;s/ : //;s/datos//;s/",//;s/""//;s/  //' $i.json &&
+            # Ahora ejecutamos todas las url de datos de todo el año y descargamos su contenido en el mismo archivo
+            while read line
+            do
+                # Eliminamos los archivos de los años ya que no nos sirven para nada
+                rm -rf $i.json
+                curl --silent --request GET --insecure "$line" >> $entero.json &&
+                # Añadimos una coma al final de todos los archivos anuales para luego concatenar todos en el mismo archivo
+                echo "," >> $entero.json
+            done < $i.json &&
+            # Le damos un respiro a la API, ya que nos baneara si hacemos demasiadas peticiones en poco tiempo
+            sleep 30
+            i=$((i+1))
         done
 
     # Al concatenar todos los meses el objeto JSON no esta bien construido

--- a/lurte.sh
+++ b/lurte.sh
@@ -1,73 +1,78 @@
-function lurte() {
-    function openAemet() {
-        # El año desde el que queremos descargar
-        from=1951
-        # El año hasta el que queremos descargar
-        to=1952
-        # El número de estación de la AEMET
-        station=9434
-        # El nombre del archivo con todos los años
-        total="${station}-total-diario"
-        # La apikey del open data de la AEMET
-        apikey=''
-                # Los años que queremos descargar
-               for i in {$from..$to}
-               do
-               # Le pasamos un nombre al archivo que generaremos con todo el año
-               entero="${i}-entero"
+#!/bin/bash
 
-                       # Los doce meses del año
-                       curl --silent --request GET --insecure \
-                         --url 'https://opendata.aemet.es/opendata/api/valores/climatologicos/diarios/datos/fechaini/'${i}'-01-01T00:00:00UTC/fechafin/'${i}'-01-31T23:59:59UTC/estacion/'${station}'/?api_key='${apikey}''  >> $i.json && curl --silent --request GET --insecure \
-                         --url 'https://opendata.aemet.es/opendata/api/valores/climatologicos/diarios/datos/fechaini/'${i}'-02-01T00:00:00UTC/fechafin/'${i}'-02-29T23:59:59UTC/estacion/'${station}'/?api_key='${apikey}''  >> $i.json && curl --silent --request GET --insecure \
-                         --url 'https://opendata.aemet.es/opendata/api/valores/climatologicos/diarios/datos/fechaini/'${i}'-03-01T00:00:00UTC/fechafin/'${i}'-03-31T23:59:59UTC/estacion/'${station}'/?api_key='${apikey}''  >> $i.json && curl --silent --request GET --insecure \
-                         --url 'https://opendata.aemet.es/opendata/api/valores/climatologicos/diarios/datos/fechaini/'${i}'-04-01T00:00:00UTC/fechafin/'${i}'-04-30T23:59:59UTC/estacion/'${station}'/?api_key='${apikey}''  >> $i.json && curl --silent --request GET --insecure \
-                         --url 'https://opendata.aemet.es/opendata/api/valores/climatologicos/diarios/datos/fechaini/'${i}'-05-01T00:00:00UTC/fechafin/'${i}'-05-31T23:59:59UTC/estacion/'${station}'/?api_key='${apikey}''  >> $i.json && curl --silent --request GET --insecure \
-                         --url 'https://opendata.aemet.es/opendata/api/valores/climatologicos/diarios/datos/fechaini/'${i}'-06-01T00:00:00UTC/fechafin/'${i}'-06-30T23:59:59UTC/estacion/'${station}'/?api_key='${apikey}''  >> $i.json && curl --silent --request GET --insecure \
-                         --url 'https://opendata.aemet.es/opendata/api/valores/climatologicos/diarios/datos/fechaini/'${i}'-07-01T00:00:00UTC/fechafin/'${i}'-07-31T23:59:59UTC/estacion/'${station}'/?api_key='${apikey}''  >> $i.json && curl --silent --request GET --insecure \
-                         --url 'https://opendata.aemet.es/opendata/api/valores/climatologicos/diarios/datos/fechaini/'${i}'-08-01T00:00:00UTC/fechafin/'${i}'-08-31T23:59:59UTC/estacion/'${station}'/?api_key='${apikey}''  >> $i.json && curl --silent --request GET --insecure \
-                         --url 'https://opendata.aemet.es/opendata/api/valores/climatologicos/diarios/datos/fechaini/'${i}'-09-01T00:00:00UTC/fechafin/'${i}'-09-30T23:59:59UTC/estacion/'${station}'/?api_key='${apikey}''  >> $i.json && curl --silent --request GET --insecure \
-                         --url 'https://opendata.aemet.es/opendata/api/valores/climatologicos/diarios/datos/fechaini/'${i}'-10-01T00:00:00UTC/fechafin/'${i}'-10-31T23:59:59UTC/estacion/'${station}'/?api_key='${apikey}''  >> $i.json && curl --silent --request GET --insecure \
-                         --url 'https://opendata.aemet.es/opendata/api/valores/climatologicos/diarios/datos/fechaini/'${i}'-11-01T00:00:00UTC/fechafin/'${i}'-11-30T23:59:59UTC/estacion/'${station}'/?api_key='${apikey}''  >> $i.json && curl --silent --request GET --insecure \
-                         --url 'https://opendata.aemet.es/opendata/api/valores/climatologicos/diarios/datos/fechaini/'${i}'-12-01T00:00:00UTC/fechafin/'${i}'-12-31T23:59:59UTC/estacion/'${station}'/?api_key='${apikey}'' >> $i.json &&
-                         # El archivo que descargamos contiene demasiadas cosas que no sirven
-                         # Vamos a quedarnos solo con la url de datos
-                         sed -i '/descripcion/d;/estado/d;/metadatos/d' $i.json &&
-                         sed -i 's/{//;s/}//;s/"//;s/ : //;s/datos//;s/",//;s/""//;s/  //' $i.json &&
-                         # Ahora ejecutamos todas las url de datos de todo el año y descargamos su contenido en el mismo archivo
-                         while read line; do
-                            # Eliminamos los archivos de los años ya que no nos sirven para nada
-                            rm -rf $i.json
-                            curl --silent --request GET --insecure "$line" >> $entero.json &&
-                            # Añadimos una coma al final de todos los archivos anuales para luego concatenar todos en el mismo archivo
-                            echo "," >> $entero.json
-                         done < $i.json &&
-                        # Le damos un respiro a la API, ya que nos baneara si hacemos demasiadas peticiones en poco tiempo
-                        sleep 30
-               done
+function openAemet() {
+    # El año desde el que queremos descargar
+    from=1951
+    # El año hasta el que queremos descargar
+    to=1952
+    # El número de estación de la AEMET
+    station=9434
+    # El nombre del archivo con todos los años
+    total="${station}-total-diario"
+    # La apikey del open data de la AEMET
+    apikey=''
 
-        # Al concatenar todos los meses el objeto JSON no esta bien construido
-        # Primero eliminamos ], excepto el último que sirve para concatenar todos los archivos en el mismo
-        sed -i 's/],/,/' *.json &&
-        # Eliminamos todos los [ excepto el primero que sirve para concatenar todos los archivos en el mismo
-        sed -i '1 ! s/\[//' *.json &&
-        # Concatenamos todos los JSON en el mismo archivo
-        cat *.json > $total.json &&
-        sed -i '$ s/,/,]/' $total.json &&
-        # Eliminamos todos los JSON con los años enteros
-        find . -name '*-entero*' -delete &&
-        # Cambiamos el separador de coma por punto
-        sed -i 's/\([0-9]\),/\1\./g' $total.json
+    # Los años que queremos descargar
+    i=$from
+    while [ $i -le $to ]
+        do
+        # Le pasamos un nombre al archivo que generaremos con todo el año
+        entero="${i}-entero"
 
-    }
+            # Los doce meses del año
+            curl --silent --request GET --insecure \
+              --url 'https://opendata.aemet.es/opendata/api/valores/climatologicos/diarios/datos/fechaini/'${i}'-01-01T00:00:00UTC/fechafin/'${i}'-01-31T23:59:59UTC/estacion/'${station}'/?api_key='${apikey}''  >> $i.json && curl --silent --request GET --insecure \
+              --url 'https://opendata.aemet.es/opendata/api/valores/climatologicos/diarios/datos/fechaini/'${i}'-02-01T00:00:00UTC/fechafin/'${i}'-02-29T23:59:59UTC/estacion/'${station}'/?api_key='${apikey}''  >> $i.json && curl --silent --request GET --insecure \
+              --url 'https://opendata.aemet.es/opendata/api/valores/climatologicos/diarios/datos/fechaini/'${i}'-03-01T00:00:00UTC/fechafin/'${i}'-03-31T23:59:59UTC/estacion/'${station}'/?api_key='${apikey}''  >> $i.json && curl --silent --request GET --insecure \
+              --url 'https://opendata.aemet.es/opendata/api/valores/climatologicos/diarios/datos/fechaini/'${i}'-04-01T00:00:00UTC/fechafin/'${i}'-04-30T23:59:59UTC/estacion/'${station}'/?api_key='${apikey}''  >> $i.json && curl --silent --request GET --insecure \
+              --url 'https://opendata.aemet.es/opendata/api/valores/climatologicos/diarios/datos/fechaini/'${i}'-05-01T00:00:00UTC/fechafin/'${i}'-05-31T23:59:59UTC/estacion/'${station}'/?api_key='${apikey}''  >> $i.json && curl --silent --request GET --insecure \
+              --url 'https://opendata.aemet.es/opendata/api/valores/climatologicos/diarios/datos/fechaini/'${i}'-06-01T00:00:00UTC/fechafin/'${i}'-06-30T23:59:59UTC/estacion/'${station}'/?api_key='${apikey}''  >> $i.json && curl --silent --request GET --insecure \
+              --url 'https://opendata.aemet.es/opendata/api/valores/climatologicos/diarios/datos/fechaini/'${i}'-07-01T00:00:00UTC/fechafin/'${i}'-07-31T23:59:59UTC/estacion/'${station}'/?api_key='${apikey}''  >> $i.json && curl --silent --request GET --insecure \
+              --url 'https://opendata.aemet.es/opendata/api/valores/climatologicos/diarios/datos/fechaini/'${i}'-08-01T00:00:00UTC/fechafin/'${i}'-08-31T23:59:59UTC/estacion/'${station}'/?api_key='${apikey}''  >> $i.json && curl --silent --request GET --insecure \
+              --url 'https://opendata.aemet.es/opendata/api/valores/climatologicos/diarios/datos/fechaini/'${i}'-09-01T00:00:00UTC/fechafin/'${i}'-09-30T23:59:59UTC/estacion/'${station}'/?api_key='${apikey}''  >> $i.json && curl --silent --request GET --insecure \
+              --url 'https://opendata.aemet.es/opendata/api/valores/climatologicos/diarios/datos/fechaini/'${i}'-10-01T00:00:00UTC/fechafin/'${i}'-10-31T23:59:59UTC/estacion/'${station}'/?api_key='${apikey}''  >> $i.json && curl --silent --request GET --insecure \
+              --url 'https://opendata.aemet.es/opendata/api/valores/climatologicos/diarios/datos/fechaini/'${i}'-11-01T00:00:00UTC/fechafin/'${i}'-11-30T23:59:59UTC/estacion/'${station}'/?api_key='${apikey}''  >> $i.json && curl --silent --request GET --insecure \
+              --url 'https://opendata.aemet.es/opendata/api/valores/climatologicos/diarios/datos/fechaini/'${i}'-12-01T00:00:00UTC/fechafin/'${i}'-12-31T23:59:59UTC/estacion/'${station}'/?api_key='${apikey}'' >> $i.json &&
+             # El archivo que descargamos contiene demasiadas cosas que no sirven
+             # Vamos a quedarnos solo con la url de datos
+             sed -i '/descripcion/d;/estado/d;/metadatos/d' $i.json &&
+             sed -i 's/{//;s/}//;s/"//;s/ : //;s/datos//;s/",//;s/""//;s/  //' $i.json &&
+             # Ahora ejecutamos todas las url de datos de todo el año y descargamos su contenido en el mismo archivo
+             while read line; do
+                 # Eliminamos los archivos de los años ya que no nos sirven para nada
+                 rm -rf $i.json
+                 curl --silent --request GET --insecure "$line" >> $entero.json &&
+                 # Añadimos una coma al final de todos los archivos anuales para luego concatenar todos en el mismo archivo
+                 echo "," >> $entero.json
+             done < $i.json &&
+             # Le damos un respiro a la API, ya que nos baneara si hacemos demasiadas peticiones en poco tiempo
+             sleep 30
+        i=$((i+1))
+        done
 
-    showLoading() {
-      mypid=$!
-      loadingText=$1
+    # Al concatenar todos los meses el objeto JSON no esta bien construido
+    # Primero eliminamos ], excepto el último que sirve para concatenar todos los archivos en el mismo
+    sed -i 's/],/,/' *.json &&
+    # Eliminamos todos los [ excepto el primero que sirve para concatenar todos los archivos en el mismo
+    sed -i '1 ! s/\[//' *.json &&
+    # Concatenamos todos los JSON en el mismo archivo
+    cat *.json > $total.json &&
+    sed -i '$ s/,/,]/' $total.json &&
+    # Eliminamos todos los JSON con los años enteros
+    find . -name '*-entero*' -delete &&
+    # Cambiamos el separador de coma por punto
+    sed -i 's/\([0-9]\),/\1\./g' $total.json
 
-      echo -ne "$loadingText\r"
+}
 
-      while kill -0 $mypid 2>/dev/null; do
+showLoading() {
+    mypid=$!
+    loadingText=$1
+
+    echo -ne "$loadingText\r"
+
+    while kill -0 $mypid 2>/dev/null
+    do
         echo -ne "$loadingText.\r"
         sleep 0.5
         echo -ne "$loadingText..\r"
@@ -77,10 +82,9 @@ function lurte() {
         echo -ne "\r\033[K"
         echo -ne "$loadingText\r"
         sleep 0.5
-      done
+    done
 
-      echo "$loadingText...Descarga completada!"
-    }
-
-    openAemet & showLoading "Descargando todos los datos de la AEMET"
+    echo "$loadingText...Descarga completada!"
 }
+
+openAemet & showLoading "Descargando todos los datos de la AEMET"

--- a/lurte.sh
+++ b/lurte.sh
@@ -1,17 +1,20 @@
 #!/bin/bash
 
+# Introducir la API-key del servicio aquí:
+APIKEY=''
+
 function openAemet() {
     # El año desde el que queremos descargar
-    from=1951
+    from=$1
     # El año hasta el que queremos descargar
-    to=1952
+    to=$2
     # El número de estación de la AEMET
-    station=9434
+    station=$3
+    # La apikey del open data de la AEMET
+    apikey=$APIKEY
+
     # El nombre del archivo con todos los años
     total="${station}-total-diario"
-    # La apikey del open data de la AEMET
-    apikey=''
-
     # Los años que queremos descargar
     i=$from
     while [ $i -le $to ]
@@ -88,4 +91,12 @@ showLoading() {
     echo "$loadingText...Descarga completada!"
 }
 
-openAemet & showLoading "Descargando todos los datos de la AEMET"
+if [ $# -ne 3 ]
+then
+    echo "Usage:"
+    echo "$0 from-year to-year station"
+    echo "Example:"
+    echo "$0 1951 1952 9434"
+    exit 1
+fi
+openAemet $1 $2 $3 & showLoading "Descargando todos los datos de la AEMET"


### PR DESCRIPTION
DISCLAIMER:  this is the worst PR I've ever made but forgot to keep track of the changes step by step and it was too late later. I'm so embarrassed. Sorry for that.

Anyway, I moved some stuff and I didn't really check if it works in the downloading part and so. I just checked it starts.

It solves:
- The issue with the  {$from..$to} that we talked about: The comprehension was applied before the variable interpolation so the result of the for was: one execution with `i == "{1951..1952}"`.
- It removes the external function, I don't really know why was that there
- It moves the hardcoded values to external parameters. (API-key remains inside the script... it might be useful to get it from environment vars?)
- It added a shebang on the top.